### PR TITLE
Remove Aero configure steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Once installed, you should be able to run `aero {command}` from within any direc
 
 ## Installing Aero Commerce
 
+### Generating a New Site
+
 Use the `new` command to create a new Aero Commerce site:
 
 ```
@@ -22,3 +24,26 @@ aero new my-site
 ```
 
 This will download the latest version and install it into the `my-site` directory.
+
+### Configuring Your Site
+
+Run the configure command in your new site:
+
+```bash
+cd my-site
+php artisan aero:configure
+```
+
+and answer the questions.
+
+Alternatively you can manually set parameters in the generated `.env` file.
+
+### Finilasing installation
+
+Finally run:
+
+```bash
+php artisan aero:install
+```
+
+to run database migrations etc.

--- a/src/Installation/RunComposerScripts.php
+++ b/src/Installation/RunComposerScripts.php
@@ -16,14 +16,10 @@ class RunComposerScripts extends InstallStep
     {
         $composer = $this->findComposer();
 
-        $noInteraction = $this->command->input->getOption('no-interaction') ? ' --no-interaction' : '';
-
         $commands = [
             $composer.' install --no-scripts --prefer-dist',
             $composer.' run-script post-root-package-install --quiet',
             $composer.' run-script post-create-project-cmd --quiet',
-            '"'.PHP_BINARY.'" artisan aero:configure --ansi'.$noInteraction,
-            '"'.PHP_BINARY.'" artisan aero:install --ansi',
             $composer.' run-script post-autoload-dump --quiet',
         ];
 


### PR DESCRIPTION
This will remove the store configuration steps from the CLI and document how to run them seperately in the readme.

This is because the configuration is seperate to generating a new site and therefore should be run seperately.