### PR TITLE
Remove timeout from installing docker

### DIFF
--- a/src/Installation/AddDocker.php
+++ b/src/Installation/AddDocker.php
@@ -24,6 +24,7 @@ class AddDocker extends InstallStep
         ];
 
         $process = new Process(implode(' && ', $commands), $this->command->path);
+        $process->setTimeout(null);
 
         if ('\\' !== DIRECTORY_SEPARATOR && posix_isatty(STDIN)) {
             $process->setTty(true);


### PR DESCRIPTION
Sometimes it takes a bit longer on slower machines and I don't see why a timeout is needed anyway since composer will take care of issues.