### PR TITLE
Fix prompting on Windows

### DIFF
--- a/src/Command.php
+++ b/src/Command.php
@@ -43,6 +43,13 @@ abstract class Command extends SymfonyCommand
      */
     public $relativePath;
 
+    /**
+     * The directory the installer was invoked from.
+     *
+     * @var string
+     */
+    public $installerWorkingDirectory;
+
     protected function verifyApplicationDoesntExist(string $directory): void
     {
         if (is_file($directory) || (is_dir($directory) && (new FilesystemIterator($directory))->valid())) {

--- a/src/InstallStep.php
+++ b/src/InstallStep.php
@@ -33,29 +33,31 @@ abstract class InstallStep implements InstallStepInterface
         exit(1);
     }
 
-    protected function findComposer(): string
+    /**
+     * @return list<string>
+     */
+    protected function composerCommand(): array
     {
-        $composerPath = getcwd().'/composer.phar';
+        $directory = $this->command->installerWorkingDirectory ?: getcwd();
+        $localPhar = $directory.DIRECTORY_SEPARATOR.'composer.phar';
 
-        if (file_exists($composerPath)) {
-            return '"'.PHP_BINARY.'" '.$composerPath;
+        if (is_file($localPhar)) {
+            return [PHP_BINARY, $localPhar];
         }
 
-        return 'composer';
+        return ['composer'];
     }
 
-    protected function runCommand(array $command): void
+    protected function findComposer(): string
     {
-        $process = new Process($command, null, null, null, null);
+        return $this->escapeCommandLine($this->composerCommand());
+    }
 
-        if ($this->interaction
-            && '\\' !== DIRECTORY_SEPARATOR && file_exists('/dev/tty') && is_readable('/dev/tty')) {
-            try {
-                $process->setTty(true);
-            } catch (RuntimeException $e) {
-                $this->command->output->writeln('Warning: '.$e->getMessage());
-            }
-        }
+    protected function runCommand(array $command, ?string $cwd = null): void
+    {
+        $process = new Process($command, $cwd, null, null, null);
+
+        $this->configureInteractiveProcess($process);
 
         $process->setTimeout(null)->run(function ($_, $line) {
             $this->command->output->write($line);
@@ -63,6 +65,72 @@ abstract class InstallStep implements InstallStepInterface
 
         if (! $process->isSuccessful()) {
             $this->errorInstall();
+        }
+    }
+
+    protected function runInteractiveCommand(array $command, ?string $cwd = null): void
+    {
+        if ($this->shouldRunInForeground()) {
+            $this->runCommandInForeground($command, $cwd);
+
+            return;
+        }
+
+        if ($this->interaction
+            && '\\' === DIRECTORY_SEPARATOR
+            && ! in_array('--no-interaction', $command, true)) {
+            $command[] = '--no-interaction';
+        }
+
+        $this->runCommand($command, $cwd);
+    }
+
+    protected function shouldRunInForeground(): bool
+    {
+        return $this->interaction
+            && '\\' === DIRECTORY_SEPARATOR
+            && defined('STDIN')
+            && stream_isatty(STDIN);
+    }
+
+    protected function runCommandInForeground(array $command, ?string $cwd = null): void
+    {
+        $previousDirectory = getcwd();
+
+        if ($cwd !== null && is_dir($cwd)) {
+            chdir($cwd);
+        }
+
+        passthru($this->escapeCommandLine($command), $exitCode);
+
+        if ($previousDirectory !== false) {
+            chdir($previousDirectory);
+        }
+
+        if ($exitCode !== 0) {
+            $this->errorInstall();
+        }
+    }
+
+    protected function escapeCommandLine(array $command): string
+    {
+        return implode(' ', array_map('escapeshellarg', $command));
+    }
+
+    protected function configureInteractiveProcess(Process $process): void
+    {
+        if (! $this->interaction || '\\' === DIRECTORY_SEPARATOR) {
+            return;
+        }
+
+        if (! file_exists('/dev/tty') || ! is_readable('/dev/tty')) {
+            return;
+        }
+
+        try {
+            $process->setTty(true);
+        } catch (RuntimeException $e) {
+            $this->command->output->writeln('Warning: '.$e->getMessage());
         }
     }
 }

--- a/src/Installation/CreateProject.php
+++ b/src/Installation/CreateProject.php
@@ -17,15 +17,14 @@ class CreateProject extends InstallStep
             $laravel = "~{$laravel}.0";
         }
 
-        $command = [
-            $this->findComposer(),
+        $command = array_merge($this->composerCommand(), [
             'create-project',
             "laravel/laravel={$laravel}",
             $this->command->relativePath,
             '--quiet',
             '--no-scripts',
             '--no-install',
-        ];
+        ]);
 
         $this->runCommand($command);
 

--- a/src/Installation/RunComposerScripts.php
+++ b/src/Installation/RunComposerScripts.php
@@ -9,23 +9,23 @@ class RunComposerScripts extends InstallStep
 {
     public function install(): void
     {
-        $composer = $this->findComposer();
-
         $commands = [
-            $composer.' update --no-scripts --prefer-dist',
-            $composer.' run-script post-root-package-install --quiet',
-            $composer.' run-script post-create-project-cmd --quiet',
-            $composer.' run-script post-autoload-dump --quiet',
+            array_merge($this->composerCommand(), ['update', '--no-scripts', '--prefer-dist']),
+            array_merge($this->composerCommand(), ['run-script', 'post-root-package-install', '--quiet']),
+            array_merge($this->composerCommand(), ['run-script', 'post-create-project-cmd', '--quiet']),
+            array_merge($this->composerCommand(), ['run-script', 'post-autoload-dump', '--quiet']),
         ];
 
-        $process = Process::fromShellCommandline(implode(' && ', $commands), $this->command->path, null, null, null);
+        foreach ($commands as $command) {
+            $process = new Process($command, $this->command->path, null, null, null);
 
-        if ($this->interaction && '\\' !== DIRECTORY_SEPARATOR && file_exists('/dev/tty') && is_readable('/dev/tty')) {
-            $process->setTty(true);
+            $process->setTimeout(null)->run(function ($_, $line) {
+                $this->command->output->write($line);
+            });
+
+            if (! $process->isSuccessful()) {
+                $this->errorInstall();
+            }
         }
-
-        $process->run(function ($_, $line) {
-            $this->command->output->write($line);
-        });
     }
 }

--- a/src/Installation/RunConfigureCommand.php
+++ b/src/Installation/RunConfigureCommand.php
@@ -18,6 +18,6 @@ class RunConfigureCommand extends InstallStep
             $command[] = '--no-interaction';
         }
 
-        $this->runCommand($command);
+        $this->runInteractiveCommand($command);
     }
 }

--- a/src/Installation/RunInstallCommand.php
+++ b/src/Installation/RunInstallCommand.php
@@ -19,6 +19,6 @@ class RunInstallCommand extends InstallStep
             $command[] = '--no-interaction';
         }
 
-        $this->runCommand($command);
+        $this->runInteractiveCommand($command);
     }
 }

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -25,6 +25,7 @@ class NewCommand extends Command
     {
         $this->input = $input;
         $this->output = new SymfonyStyle($input, $output);
+        $this->installerWorkingDirectory = getcwd() ?: '';
         $this->project = $input->getArgument('project');
 
         if (! $this->project) {


### PR DESCRIPTION
During testing of `aero new` on Windows for an upcoming project, I noticed that when the installer reached the point where it's meant to prompt the user for their store name, database and Elasticsearch details, it was skipping straight through all of this and accepting the defaults without giving the user chance to correct them.

This PR fixes that issue - Cursor assisted in the fixes. I've tested this version of the CLI on my Windows VM and my Mac, and I was able to install new Aero sites - with pausing in the correct place to prompt the user for details - on both.

The CLI version number will need to be bumped if this PR is merged and released.
